### PR TITLE
replace `HEADSCALE_SERVER_URL` with `HEADSCALE_DOMAIN_NAME` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ your `fly.toml` configuration file.
 
 1. Create a CNAME entry for your Fly.io application
 2. Run `fly certs add <custom_domain>`
-3. Set the `HEADSCALE_SERVER_URL=https://<custom_domain>` in the `fly.toml`'s `[env]` section and re-deploy
+3. Set the `HEADSCALE_DOMAIN_NAME=<custom_domain>` in the `fly.toml`'s `[env]` section and re-deploy
 
 See also the related documentation on [Fly.io: Custom domains](https://fly.io/docs/networking/custom-domain/).
 
@@ -148,7 +148,7 @@ __System variables__
 | `AWS_REGION`            | (automatic) |                                                                                                                                                |
 | `AWS_ENDPOINT_URL_S3`   | (automatic) |                                                                                                                                                |
 | `BUCKET_NAME`           | (automatic) |                                                                                                                                                |
-| `FLY_APP_NAME`          | (automatic) | Used to determine the Headscale server URL, if `HEADSCALE_SERVER_URL` is not set.                                                              |
+| `FLY_APP_NAME`          | (automatic) | Used to determine the Headscale server URL, if `HEADSCALE_DOMAIN_NAME` is not set.                                                              |
 
 __Security variables__
 
@@ -161,8 +161,8 @@ __Headscale configuration variables__
 
 | Variable                                         | Default                              | Description                                                                                                                                                                                                                                                                                        |
 |--------------------------------------------------|--------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `HEADSCALE_SERVER_URL`                           | `https://${FLY_APP_NAME}.fly.dev`    | URL of the Headscale server.                                                                                                                                                                                                                                                                       |
-| `HEADSCALE_DNS_BASE_DOMAIN`                      | `tailnet`                            | Base domain for members in the Tailnet. This **must not** be a part of the `HEADSCALE_SERVER_URL`.                                                                                                                                                                                                 |
+| `HEADSCALE_DOMAIN_NAME`                           | `${FLY_APP_NAME}.fly.dev`    | URL of the Headscale server.                                                                                                                                                                                                                                                                       |
+| `HEADSCALE_DNS_BASE_DOMAIN`                      | `tailnet`                            | Base domain for members in the Tailnet. This **must not** be a part of the `HEADSCALE_DOMAIN_NAME`.                                                                                                                                                                                                 |
 | `HEADSCALE_LOG_LEVEL`                            | `info`                               | Log level for the Headscale server.                                                                                                                                                                                                                                                                |
 | `HEADSCALE_PREFIXES_V4`                          | `100.64.0.0/10`                      | Prefix for IP-v4 addresses of nodes in the Tailnet.                                                                                                                                                                                                                                                |
 | `HEADSCALE_PREFIXES_V6`                          | `fd7a:115c:a1e0::/48`                | Prefix for IP-v6 addresses of nodes in the Tailnet.                                                                                                                                                                                                                                                |

--- a/fly.example.toml
+++ b/fly.example.toml
@@ -34,6 +34,6 @@ swap_size_mb = 128
   size = "shared-cpu-1x"
 
 # [env]
-#   HEADSCALE_SERVER_URL = "https://vpn.example.com"
+#   HEADSCALE_DOMAIN_NAME = "vpn.example.com"
 #   HEADSCALE_OIDC_ISSUER = "https://mykeycloak.org/realms/main"
 #   HEADSCALE_OIDC_CLIENT_ID = "headscale"

--- a/headscale-fly-io/config.template.yaml
+++ b/headscale-fly-io/config.template.yaml
@@ -1,4 +1,4 @@
-server_url: https://${HEADSCALE_SERVER_URL}
+server_url: https://${HEADSCALE_DOMAIN_NAME}
 listen_addr: 0.0.0.0:8080
 metrics_listen_addr: 0.0.0.0:8081
 

--- a/headscale-fly-io/entrypoint.sh
+++ b/headscale-fly-io/entrypoint.sh
@@ -103,8 +103,14 @@ if [ "${ENTRYPOINT_DEBUG:-}" = "true" ]; then
     set -x
 fi
 
+# The HEADSCALE_SERVER_URL variable was removed.
+if [ -n "${HEADSCALE_SERVER_URL:-}" ]; then
+    error "HEADSCALE_SERVER_URL is no longer supported, set HEADSCALE_DOMAIN_NAME instead"
+    exit 1
+fi
+
 # Set default values for configuration variables for use with envsubst.
-export HEADSCALE_SERVER_URL="${HEADSCALE_SERVER_URL:-https://${FLY_APP_NAME}.fly.dev}"
+export HEADSCALE_DOMAIN_NAME="${HEADSCALE_DOMAIN_NAME:-${FLY_APP_NAME}.fly.dev}"
 export HEADSCALE_DNS_BASE_DOMAIN="${HEADSCALE_DNS_BASE_DOMAIN:-tailnet}"
 export HEADSCALE_LOG_LEVEL="${HEADSCALE_LOG_LEVEL:-info}"
 export HEADSCALE_PREFIXES_V4="${HEADSCALE_PREFIXES_V4:-100.64.0.0/10}"


### PR DESCRIPTION
We used the `HEADSCALE_SERVER_URL` in the generated Headscale config such that it was prefixed with `https://`, resulting in `https://https://...`, which apparently Headscale accepted but we should still fix it. Introducing `HEADSCALE_DOMAIN_NAME` instead as that will allow us to use the domain name without string manipulation if we need it in the future, and HTTPS is implied when deploying on Fly.io so we don't need that as part of the variable.
