### PR TITLE
Add Headplane Web UI Integration

### DIFF
--- a/headscale-fly-io/Dockerfile
+++ b/headscale-fly-io/Dockerfile
@@ -8,16 +8,20 @@ RUN arch=$(cat /tmp/arch) &&\
     tar -xf litestream-v0.3.13-linux-${arch}.tar.gz
 
 FROM alpine
-RUN apk add age envsubst
+RUN apk add age envsubst nginx nodejs npm
 COPY --from=ghcr.io/juanfont/headscale:v0.27.1 ko-app/headscale /usr/bin/headscale
 COPY --from=litestream /litestream /usr/bin/litestream
 COPY --from=minio/mc:RELEASE.2024-10-02T08-27-28Z /usr/bin/mc /usr/bin/mc
+COPY --from=ghcr.io/tale/headplane:0.6.1 /app/build /opt/headplane/build
+COPY --from=ghcr.io/tale/headplane:0.6.1 /app/drizzle /opt/headplane/drizzle
+COPY --from=ghcr.io/tale/headplane:0.6.1 /app/node_modules /opt/headplane/node_modules
+COPY --from=ghcr.io/tale/headplane:0.6.1 /var/lib/headplane /var/lib/headplane
 WORKDIR /etc/headscale
 VOLUME /var/lib/headscale
-COPY entrypoint.sh litestream-entrypoint.sh config.template.yaml config-oidc.template.yaml .
+COPY entrypoint.sh litestream-entrypoint.sh config.template.yaml config-oidc.template.yaml config-headplane.template.yaml nginx.conf ./
 RUN addgroup -S headscale && adduser -S headscale -G headscale
-RUN mkdir -p /etc/headscale /var/lib/headscale /var/run/headscale && \
+RUN mkdir -p /etc/headscale /var/lib/headscale /var/run/headscale /var/lib/headplane /run/nginx && \
     touch /etc/litestream.yml && \
-    chown -R headscale:headscale /etc/headscale /var/lib/headscale /var/run/headscale /etc/litestream.yml
+    chown -R headscale:headscale /etc/headscale /var/lib/headscale /var/run/headscale /var/lib/headplane /etc/litestream.yml /run/nginx /opt/headplane
 USER headscale
 ENTRYPOINT [ "/bin/sh", "/etc/headscale/entrypoint.sh" ]

--- a/headscale-fly-io/config-headplane.template.yaml
+++ b/headscale-fly-io/config-headplane.template.yaml
@@ -1,0 +1,34 @@
+# Headplane configuration template
+# Environment variables will be substituted during container startup
+
+headscale:
+  url: http://localhost:8888
+  config_path: /etc/headscale/config.yaml
+  config_strict: true
+
+server:
+  # Headplane will listen on port 3000 and be reverse-proxied by nginx
+  host: 127.0.0.1
+  port: 3000
+  
+  # Base URL - must be the public URL where Headplane is accessible (for OIDC callbacks)
+  base_url: ${HEADPLANE_BASE_URL}
+  
+  # Cookie secret for encrypting session data (must be exactly 32 characters)
+  cookie_secret: ${HEADPLANE_COOKIE_SECRET}
+  
+  # Cookie settings for reverse proxy (set to true since Fly.io handles TLS)
+  cookie_secure: true
+  
+  # Data path for headplane state
+  data_path: /var/lib/headplane
+
+# Integration settings for advanced features
+integration:
+  # Enable process inspection for network management features
+  proc:
+    enabled: ${HEADPLANE_PROC_ENABLED}
+
+# Optional: OIDC Configuration for SSO authentication
+# Uncomment and configure to enable OIDC login
+${HEADPLANE_OIDC_CONFIG}

--- a/headscale-fly-io/config.template.yaml
+++ b/headscale-fly-io/config.template.yaml
@@ -1,5 +1,5 @@
 server_url: https://${HEADSCALE_DOMAIN_NAME}
-listen_addr: 0.0.0.0:8080
+listen_addr: 0.0.0.0:8888
 metrics_listen_addr: 0.0.0.0:8081
 grpc_listen_addr: 0.0.0.0:50443
 grpc_allow_insecure: true # We use Fly.io's TLS termination.

--- a/headscale-fly-io/nginx.conf
+++ b/headscale-fly-io/nginx.conf
@@ -1,0 +1,75 @@
+worker_processes auto;
+pid /run/nginx/nginx.pid;
+error_log /dev/stderr warn;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    access_log /dev/stdout;
+    
+    # Set temp paths to writable locations
+    client_body_temp_path /tmp/nginx_client_body;
+    proxy_temp_path /tmp/nginx_proxy;
+    fastcgi_temp_path /tmp/nginx_fastcgi;
+    uwsgi_temp_path /tmp/nginx_uwsgi;
+    scgi_temp_path /tmp/nginx_scgi;
+    
+    # Required for WebSocket support
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+    
+    # Detect the forwarded protocol from Fly.io
+    map $http_x_forwarded_proto $forwarded_scheme {
+        default $scheme;
+        https https;
+        http http;
+    }
+
+    server {
+        listen 8080;
+        server_name _;
+        
+        # Set the correct port in redirects (hide internal port)
+        port_in_redirect off;
+        absolute_redirect off;
+
+        # Redirect root to /admin
+        location = / {
+            return 301 /admin;
+        }
+
+        # Headplane is served under /admin
+        # Since headplane was built with __INTERNAL_PREFIX=/admin, it expects the /admin path
+        location /admin {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_buffering off;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_scheme;
+            proxy_redirect http:// $forwarded_scheme://;
+        }
+
+        # Headscale handles all other paths
+        location / {
+            proxy_pass http://127.0.0.1:8888/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_buffering off;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $forwarded_scheme;
+            proxy_redirect http:// $forwarded_scheme://;
+            add_header Strict-Transport-Security "max-age=15552000; includeSubDomains" always;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR integrates [Headplane v0.6.1](https://headplane.net/), a full-featured web-based admin interface for Headscale, into the deployment. Headplane provides a modern UI for managing your Tailnet without requiring SSH access or CLI commands.

## Changes

### Core Integration

- **Headplane v0.6.1**: Uses the official container image from `ghcr.io/tale/headplane:0.6.1`
- **Nginx Reverse Proxy**: Added nginx to route traffic between Headscale and Headplane:
  - `/` → Headscale (API and control plane)
  - `/admin` → Headplane (web UI)
- **Disabled by Default**: Headplane is opt-in and requires `HEADPLANE_ENABLED=true` to activate

### Features

Headplane provides:
- 👥 Single-sign-on (OIDC) integration
- 🔎 Detailed Tailnet overview and host information  
- 📝 Configure Headscale settings including networking and auth controls
- 🔐 API key authentication as fallback

### Configuration

#### Basic Setup (API Key Auth)
```toml
[env]
  HEADPLANE_ENABLED = "true"
```

Then generate an API key:
```bash
fly ssh console -C "headscale apikeys create --expiration 90d"
```

#### Advanced Setup (OIDC SSO)
```bash
fly secrets set HEADPLANE_OIDC_CLIENT_SECRET=<your-secret>
fly secrets set HEADPLANE_OIDC_HEADSCALE_API_KEY=$(fly ssh console -C "headscale apikeys create --expiration 999d")
```

```toml
[env]
  HEADPLANE_ENABLED = "true"
  HEADPLANE_OIDC_ISSUER = "https://accounts.google.com"
  HEADPLANE_OIDC_CLIENT_ID = "your-client-id"
```

**Note**: Using the same OIDC client for both Headscale and Headplane provides the best user experience.

### New Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `HEADPLANE_ENABLED` | `false` | Enable/disable Headplane web UI |
| `HEADPLANE_BASE_URL` | `https://${HEADSCALE_DOMAIN_NAME}` | Public URL for OIDC callbacks |
| `HEADPLANE_COOKIE_SECRET` | (auto-generated) | Cookie encryption secret |
| `HEADPLANE_PROC_ENABLED` | `true` | Process inspection for network features |
| `HEADPLANE_OIDC_ISSUER` | n/a | OIDC issuer URL |
| `HEADPLANE_OIDC_CLIENT_ID` | n/a | OIDC client ID |
| `HEADPLANE_OIDC_CLIENT_SECRET` | n/a | OIDC client secret (use `fly secrets set`) |
| `HEADPLANE_OIDC_HEADSCALE_API_KEY` | n/a | Headscale API key (use `fly secrets set`) |
| `HEADPLANE_OIDC_SCOPE` | `openid email profile` | OIDC scopes |
| `HEADPLANE_OIDC_USE_PKCE` | `true` | Use PKCE for security |
| `HEADPLANE_OIDC_DISABLE_API_KEY_LOGIN` | `false` | Disable API key login when OIDC enabled |
| `HEADPLANE_OIDC_TOKEN_ENDPOINT_AUTH_METHOD` | `client_secret_basic` | Token endpoint auth method |

### Technical Details

- **Container Changes**:
  - Added nginx package and configuration
  - Copies Headplane files from official image (build artifacts, dependencies, drizzle migrations)
  
- **Entrypoint Updates**:
  - Generates Headplane configuration with OIDC support
  - Starts Headplane and nginx before Headscale
  - All services log to stdout/stderr for Fly.io logging

- **Removed Agent Support**: The Headplane Agent (for SSH features) does not work properly on Fly.io and has been excluded

### Documentation

- Updated README with comprehensive Headplane setup instructions
- Added environment variable reference table
- Documented OIDC configuration workflow
- Clarified Headplane is disabled by default

## Testing

Tested on Fly.io with:
- ✅ Basic deployment with API key authentication
- ✅ OIDC integration with Google
- ✅ Nginx reverse proxy routing
- ✅ Headscale functionality unchanged when Headplane disabled
- ✅ All logs visible in `fly logs`

## Breaking Changes

None. Headplane is disabled by default and existing deployments continue to work unchanged.

## Related

Resolves #25
