### PR TITLE
feat: expose gRPC endpoint through nginx reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,15 @@ there, or use the Headscale CLI locally to remotely control it. For this, you mu
 by connecting via SSH and running `headscale apikeys create`.
 
 Then, locally, make sure you have the same version of the Headscale CLI installed that is running on your Fly.io app
-and follow [as documented](https://headscale.net/ref/remote-cli/?h=api#download-and-configure-headscale). We use the
-same typical gRPC port (`50443`).
+and follow [as documented](https://headscale.net/ref/remote-cli/?h=api#download-and-configure-headscale).
 
-    $ export HEADSCALE_CLI_ADDRESS=${FLY_APP_NAME}.fly.dev:50443
+The gRPC endpoint is exposed at the `/headscale.` path. Connect to port 443 (Fly.io's TLS termination):
+
+    $ export HEADSCALE_CLI_ADDRESS=${FLY_APP_NAME}.fly.dev:443
     $ export HEADSCALE_CLI_API_KEY=...
     $ headscale node list
+
+**Note:** Fly.io handles TLS termination on port 443 and forwards traffic to nginx on port 8080 with HTTP/2 enabled. Nginx then proxies the gRPC traffic to the local headscale instance on port 50443.
 
 ## Updates
 
@@ -195,6 +198,9 @@ Both Headscale and Headplane log to stdout/stderr, so all logs are visible in `f
 Headplane runs alongside Headscale in the same container, with nginx routing:
 - `/` → Headscale (API and control plane)
 - `/admin` → Headplane (web UI)
+- `/headscale.*` → Headscale gRPC endpoint (for remote CLI access)
+
+Fly.io handles TLS termination on port 443 and forwards traffic to nginx on port 8080 with HTTP/2. Nginx then acts as a reverse proxy to the internal services.
 
 For more information, see the [Headplane documentation](https://headplane.net/).
 

--- a/fly.example.toml
+++ b/fly.example.toml
@@ -25,15 +25,6 @@ swap_size_mb = 128
     timeout = "5s"
     path = "/health"
 
-[[services]]
-  internal_port = 50443
-  protocol = "tcp"
-  [[services.ports]]
-    handlers = ["tls"]
-    port = "50443"
-  [services.ports.tls_options]
-    alpn = ["h2"]
-
 [[metrics]]
   port = 8081
   path = "/metrics"

--- a/headscale-fly-io/nginx.conf
+++ b/headscale-fly-io/nginx.conf
@@ -30,7 +30,7 @@ http {
     }
 
     server {
-        listen 8080;
+        listen 8080 http2;
         server_name _;
         
         # Set the correct port in redirects (hide internal port)
@@ -40,6 +40,11 @@ http {
         # Redirect root to /admin
         location = / {
             return 301 /admin;
+        }
+
+        # gRPC endpoint for remote CLI access
+        location /headscale. {
+            grpc_pass grpc://127.0.0.1:50443;
         }
 
         # Headplane is served under /admin


### PR DESCRIPTION
Fixes #31 

## Summary

This PR updates the nginx configuration to expose the Headscale gRPC endpoint through the same reverse proxy that handles HTTP traffic, instead of exposing it as a separate TCP service.

## Changes

### 1. Updated `nginx.conf`

- Added `http2` to the listen directive to enable HTTP/2 (required for gRPC)
- Added new location block `/headscale.` to proxy gRPC traffic to the local Headscale instance

```nginx
listen 8080 http2;

# gRPC endpoint for remote CLI access
location /headscale. {
    grpc_pass grpc://127.0.0.1:50443;
}
```

### 2. Updated `fly.example.toml`

- Removed the `[[services]]` section that exposed port 50443 directly
- All traffic now flows through the single `[http_service]` on port 8080

### 3. Updated `README.md`

- Updated CLI remote access instructions to reflect the new connection method (port 443 instead of 50443)
- Added technical details about the gRPC endpoint in the Architecture section
- Clarified that Fly.io handles TLS termination, not nginx

## Motivation

### 1. Simplified Management

Having a single port (8080) for all services reduces configuration complexity and makes the deployment easier to understand and maintain.

### 2. Platform Compatibility

This approach is compatible with platforms that only allow exposing a single port per service, such as **AWS Lightsail**. Previously, deployments on such platforms would not have been able to expose both the HTTP API and gRPC endpoint.

### 3. Follows Official Recommendations

This implementation follows the pattern documented in the official Headscale documentation:

- [Remote CLI - Behind a proxy](https://headscale.net/0.27.1/ref/remote-cli/#behind-a-proxy): States that "It is possible to run the gRPC remote endpoint behind a reverse proxy, like Nginx, and have it run on the same port as headscale."
- [Production example](https://github.com/kradalby/dotfiles/blob/4489cdbb19cddfbfae82cd70448a38fde5a76711/machines/headscale.oracldn/headscale.nix#L61-L91): Real-world NixOS configuration showing nginx proxying gRPC traffic

## Testing

After this change, the remote CLI can be used as follows:

```bash
export HEADSCALE_CLI_ADDRESS=your-app.fly.dev:443
export HEADSCALE_CLI_API_KEY=your-api-key
headscale node list
```

The connection flow is:
1. Client connects to Fly.io on port 443 (HTTPS/HTTP2)
2. Fly.io terminates TLS and forwards to nginx on port 8080
3. Nginx routes based on path:
   - `/headscale.*` → gRPC endpoint (port 50443 locally)
   - `/admin` → Headplane UI (port 3000 locally)
   - `/` → Headscale HTTP API (port 8888 locally)

## Breaking Changes

Users will need to update their CLI configuration from:

```bash
export HEADSCALE_CLI_ADDRESS=your-app.fly.dev:50443
```

to:

```bash
export HEADSCALE_CLI_ADDRESS=your-app.fly.dev:443
```

This change should be documented in release notes.

## References

- [Headscale Remote CLI Documentation](https://headscale.net/0.27.1/ref/remote-cli/#troubleshooting)
- [Production nginx configuration example](https://github.com/kradalby/dotfiles/blob/4489cdbb19cddfbfae82cd70448a38fde5a76711/machines/headscale.oracldn/headscale.nix#L61-L91)
- [Nginx gRPC module documentation](http://nginx.org/en/docs/http/ngx_http_grpc_module.html)
