### PR TITLE
fix: adapt Headplane 0.7 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Then set the following environment variables:
 
 ```bash
 $ fly secrets set HEADPLANE_OIDC_CLIENT_SECRET=<your-client-secret>
-$ fly secrets set HEADPLANE_OIDC_HEADSCALE_API_KEY=$(fly ssh console -C "headscale apikeys create --expiration 999d")
+$ fly secrets set HEADPLANE_HEADSCALE_API_KEY=$(fly ssh console -C "headscale apikeys create --expiration 999d")
 ```
 
 Add to your `fly.toml`:
@@ -275,20 +275,23 @@ __Headscale configuration variables__
 
 __Headplane configuration variables__
 
-| Variable                                    | Default                            | Description                                                                              |
-| ------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------- |
-| `HEADPLANE_ENABLED`                         | `false`                            | Enable or disable the Headplane web UI.                                                  |
-| `HEADPLANE_BASE_URL`                        | `https://${HEADSCALE_DOMAIN_NAME}` | Public URL where Headplane is accessible (required for OIDC callback URLs)               |
-| `HEADPLANE_COOKIE_SECRET`                   | (auto)                             | Cookie encryption secret (automatically generated if not provided)                       |
-| `HEADPLANE_PROC_ENABLED`                    | `true`                             | Enable process inspection for network management features                                |
-| `HEADPLANE_OIDC_ISSUER`                     | n/a                                | OIDC issuer URL for Headplane SSO (e.g., `https://accounts.google.com`)                  |
-| `HEADPLANE_OIDC_CLIENT_ID`                  | n/a                                | OIDC client ID for Headplane. **Important:** Should match Headscale's OIDC client ID     |
-| `HEADPLANE_OIDC_CLIENT_SECRET`              | n/a                                | OIDC client secret for Headplane. **Important:** Use `fly secrets set`                   |
-| `HEADPLANE_OIDC_HEADSCALE_API_KEY`          | n/a                                | Headscale API key for OIDC flow. **Important:** Use `fly secrets set`                    |
-| `HEADPLANE_OIDC_SCOPE`                      | `openid email profile`             | OIDC scopes to request                                                                   |
-| `HEADPLANE_OIDC_USE_PKCE`                   | `true`                             | Use PKCE for additional security (requires OIDC provider support)                        |
-| `HEADPLANE_OIDC_DISABLE_API_KEY_LOGIN`      | `false`                            | Disable traditional API key login when OIDC is enabled                                   |
-| `HEADPLANE_OIDC_TOKEN_ENDPOINT_AUTH_METHOD` | `client_secret_basic`              | Token endpoint authentication method (e.g., `client_secret_post`, `client_secret_basic`) |
+| Variable                                      | Default                            | Description                                                                                               |
+| --------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `HEADPLANE_ENABLED`                           | `false`                            | Enable or disable the Headplane web UI.                                                                   |
+| `HEADPLANE_BASE_URL`                          | `https://${HEADSCALE_DOMAIN_NAME}` | Public URL where Headplane is accessible (required for OIDC callback URLs).                               |
+| `HEADPLANE_HEADSCALE_PUBLIC_URL`              | `https://${HEADSCALE_DOMAIN_NAME}` | Public Headscale URL displayed in registration commands.                                                  |
+| `HEADPLANE_HEADSCALE_API_KEY`                 | n/a                                | Headscale API key for OIDC and server-side operations. **Important:** Use `fly secrets set`.              |
+| `HEADPLANE_OIDC_HEADSCALE_API_KEY`            | n/a                                | Deprecated alias for `HEADPLANE_HEADSCALE_API_KEY`, retained for existing deployments.                   |
+| `HEADPLANE_COOKIE_SECRET`                     | (auto)                             | Cookie encryption secret (automatically generated if not provided).                                      |
+| `HEADPLANE_PROC_ENABLED`                      | `true`                             | Enable process inspection for network management features.                                               |
+| `HEADPLANE_OIDC_ISSUER`                       | n/a                                | OIDC issuer URL for Headplane SSO (e.g., `https://accounts.google.com`).                                 |
+| `HEADPLANE_OIDC_CLIENT_ID`                    | n/a                                | OIDC client ID for Headplane. **Important:** Should match Headscale's OIDC client ID.                    |
+| `HEADPLANE_OIDC_CLIENT_SECRET`                | n/a                                | OIDC client secret for Headplane. **Important:** Use `fly secrets set`.                                  |
+| `HEADPLANE_OIDC_SCOPE`                        | `openid email profile`             | OIDC scopes to request.                                                                                    |
+| `HEADPLANE_OIDC_USE_PKCE`                     | `true`                             | Use PKCE for additional security (requires OIDC provider support).                                       |
+| `HEADPLANE_OIDC_DISABLE_API_KEY_LOGIN`        | `false`                            | Disable traditional API key login when OIDC is enabled.                                                  |
+| `HEADPLANE_OIDC_TOKEN_ENDPOINT_AUTH_METHOD`   | `client_secret_basic`              | Token endpoint authentication method (e.g., `client_secret_post`, `client_secret_basic`).                |
+| `HEADPLANE_OIDC_DEFAULT_ROLE`                 | `member`                           | Role assigned to new OIDC users after the first owner is created.                                        |
 
 __Litestream configuration variables__
 

--- a/headscale-fly-io/Dockerfile
+++ b/headscale-fly-io/Dockerfile
@@ -7,15 +7,14 @@ RUN arch=$(cat /tmp/arch) &&\
     wget https://github.com/benbjohnson/litestream/releases/download/v0.3.13/litestream-v0.3.13-linux-${arch}.tar.gz && \
     tar -xf litestream-v0.3.13-linux-${arch}.tar.gz
 
-FROM alpine
-RUN apk add age envsubst nginx nodejs npm
+FROM node:24-alpine
+RUN apk add age envsubst nginx
 COPY --from=ghcr.io/juanfont/headscale:v0.29.3 ko-app/headscale /usr/bin/headscale
 COPY --from=litestream /litestream /usr/bin/litestream
 COPY --from=minio/mc:RELEASE.2024-10-02T08-27-28Z /usr/bin/mc /usr/bin/mc
-COPY --from=ghcr.io/tale/headplane:0.6.3 /app/build /opt/headplane/build
-COPY --from=ghcr.io/tale/headplane:0.6.3 /app/drizzle /opt/headplane/drizzle
-COPY --from=ghcr.io/tale/headplane:0.6.3 /app/node_modules /opt/headplane/node_modules
-COPY --from=ghcr.io/tale/headplane:0.6.3 /var/lib/headplane /var/lib/headplane
+COPY --from=ghcr.io/tale/headplane:0.7.0 /app/build /opt/headplane/build
+COPY --from=ghcr.io/tale/headplane:0.7.0 /app/drizzle /opt/headplane/drizzle
+COPY --from=ghcr.io/tale/headplane:0.7.0 /var/lib/headplane /var/lib/headplane
 WORKDIR /etc/headscale
 VOLUME /var/lib/headscale
 COPY entrypoint.sh litestream-entrypoint.sh config.template.yaml config-oidc.template.yaml config-headplane.template.yaml litestream-headplane.template.yaml nginx.template.conf ./

--- a/headscale-fly-io/config-headplane.template.yaml
+++ b/headscale-fly-io/config-headplane.template.yaml
@@ -3,6 +3,8 @@
 
 headscale:
   url: http://localhost:8888
+  public_url: ${HEADPLANE_HEADSCALE_PUBLIC_URL}
+${HEADPLANE_HEADSCALE_API_KEY_CONFIG}
   config_path: /etc/headscale/config.yaml
   config_strict: true
 

--- a/headscale-fly-io/entrypoint.sh
+++ b/headscale-fly-io/entrypoint.sh
@@ -27,6 +27,14 @@ assert_is_set() {
   fi
 }
 
+assert_is_not_empty() {
+  eval "val=\${$1:-}"
+  if [ -z "$val" ]; then
+    error "missing non-empty environment variable \"$1\""
+    exit 1
+  fi
+}
+
 maybe_idle() {
   if [ "${ENTRYPOINT_IDLE:-false}" = "true" ]; then
     info "ENTRYPOINT_IDLE=true, entering idle state"
@@ -125,28 +133,40 @@ write_headplane_config() {
   if [ -z "${HEADPLANE_BASE_URL:-}" ]; then
     export HEADPLANE_BASE_URL="https://${HEADSCALE_DOMAIN_NAME}"
   fi
+  export HEADPLANE_HEADSCALE_PUBLIC_URL="${HEADPLANE_HEADSCALE_PUBLIC_URL:-https://${HEADSCALE_DOMAIN_NAME}}"
+
+  # HEADPLANE_OIDC_HEADSCALE_API_KEY is retained for existing deployments.
+  if [ -z "${HEADPLANE_HEADSCALE_API_KEY:-}" ] && [ -n "${HEADPLANE_OIDC_HEADSCALE_API_KEY:-}" ]; then
+    export HEADPLANE_HEADSCALE_API_KEY="${HEADPLANE_OIDC_HEADSCALE_API_KEY}"
+  fi
+  if [ -n "${HEADPLANE_HEADSCALE_API_KEY:-}" ]; then
+    export HEADPLANE_HEADSCALE_API_KEY_CONFIG="  api_key: \"${HEADPLANE_HEADSCALE_API_KEY}\""
+  else
+    export HEADPLANE_HEADSCALE_API_KEY_CONFIG="# api_key: not configured"
+  fi
 
   # Generate OIDC configuration if enabled
   if [ -n "${HEADPLANE_OIDC_ISSUER:-}" ]; then
     info "enabling OIDC configuration for Headplane"
     assert_is_set HEADPLANE_OIDC_CLIENT_ID
     assert_is_set HEADPLANE_OIDC_CLIENT_SECRET
-    assert_is_set HEADPLANE_OIDC_HEADSCALE_API_KEY
+    assert_is_not_empty HEADPLANE_HEADSCALE_API_KEY
     
     export HEADPLANE_OIDC_SCOPE="${HEADPLANE_OIDC_SCOPE:-openid email profile}"
     export HEADPLANE_OIDC_USE_PKCE="${HEADPLANE_OIDC_USE_PKCE:-true}"
     export HEADPLANE_OIDC_DISABLE_API_KEY_LOGIN="${HEADPLANE_OIDC_DISABLE_API_KEY_LOGIN:-false}"
     export HEADPLANE_OIDC_TOKEN_ENDPOINT_AUTH_METHOD="${HEADPLANE_OIDC_TOKEN_ENDPOINT_AUTH_METHOD:-client_secret_basic}"
+    export HEADPLANE_OIDC_DEFAULT_ROLE="${HEADPLANE_OIDC_DEFAULT_ROLE:-member}"
     
     export HEADPLANE_OIDC_CONFIG="oidc:
   issuer: ${HEADPLANE_OIDC_ISSUER}
   client_id: ${HEADPLANE_OIDC_CLIENT_ID}
   client_secret: ${HEADPLANE_OIDC_CLIENT_SECRET}
-  headscale_api_key: ${HEADPLANE_OIDC_HEADSCALE_API_KEY}
   scope: ${HEADPLANE_OIDC_SCOPE}
   use_pkce: ${HEADPLANE_OIDC_USE_PKCE}
   disable_api_key_login: ${HEADPLANE_OIDC_DISABLE_API_KEY_LOGIN}
-  token_endpoint_auth_method: ${HEADPLANE_OIDC_TOKEN_ENDPOINT_AUTH_METHOD}"
+  token_endpoint_auth_method: ${HEADPLANE_OIDC_TOKEN_ENDPOINT_AUTH_METHOD}
+  default_role: ${HEADPLANE_OIDC_DEFAULT_ROLE}"
   else
     export HEADPLANE_OIDC_CONFIG="# oidc: not configured"
   fi
@@ -166,7 +186,7 @@ start_headplane() {
 
   info "starting headplane in background (logs to stdout/stderr)"
   cd /opt/headplane
-  HEADPLANE_CONFIG_PATH=/etc/headscale/config-headplane.yaml NODE_PATH=/opt/headplane/node_modules node /opt/headplane/build/server/index.js 2>&1 &
+  HEADPLANE_CONFIG_PATH=/etc/headscale/config-headplane.yaml node /opt/headplane/build/server/index.js 2>&1 &
   HEADPLANE_PID=$!
   info "headplane started with PID $HEADPLANE_PID"
 }


### PR DESCRIPTION
## Summary

- upgrade the bundled Headplane runtime from 0.6.3 to 0.7.0
- adapt to Headplane's self-contained build by dropping the `node_modules` copy and running on Node 24
- migrate the API key to `headscale.api_key`, keeping `HEADPLANE_OIDC_HEADSCALE_API_KEY` as a compatibility alias
- expose `headscale.public_url` and `oidc.default_role`

## Why

Renovate PR #44 only updates the image tag and fails, because Headplane 0.7 no longer ships `/app/node_modules` — the runtime is a self-contained bundle on distroless Node 24. Supersedes #44.

0.7 also moves the Headscale API key out of the `oidc` block into `headscale.api_key`, and adds `oidc.default_role`, without which OIDC users are left in pending approval.

`headscale.public_url` is unrelated to 0.7 but belongs with it: without it Headplane prints the internal `http://localhost:8888` in the `tailscale up --login-server=...` registration command.

## Compatibility

`HEADPLANE_OIDC_HEADSCALE_API_KEY` still works and feeds `headscale.api_key`, so existing deployments need no changes. The key is rendered as a whole config line, so it is omitted entirely when unset. `assert_is_not_empty` replaces `assert_is_set` for it — the latter accepted an empty string, which produced a config that failed at runtime instead of at startup.

## Verification

Ran against a local `docker build` of this branch:

- OIDC configured, key supplied via the legacy `HEADPLANE_OIDC_HEADSCALE_API_KEY` — renders `api_key: "..."`, `public_url: https://...` and `default_role: member`, with no leftover `oidc.headscale_api_key`
- OIDC configured, key empty — startup aborts with `missing non-empty environment variable "HEADPLANE_HEADSCALE_API_KEY"`
- Headplane enabled without OIDC — renders `# api_key: not configured` and `# oidc: not configured`
- `sh -n headscale-fly-io/entrypoint.sh`

The pull request workflow performs the linux/amd64 and linux/arm64 Docker build.
